### PR TITLE
Added QuestionPro links to About

### DIFF
--- a/src/components/about.jsx
+++ b/src/components/about.jsx
@@ -105,6 +105,8 @@ const About = ({ authenticated }) => (
       ) : (
         false
       )}
+      
+      <p>Thanks to <a href="https://www.questionpro.com/" target="_blank">QuestionPro's</a> wide range of <a href="https://www.questionpro.com/survey-templates/" target="_blank">free survey templates</a> designed by industry experts.</p>
     </div>
   </div>
 );


### PR DESCRIPTION
To receive non-profit access to QuestionPro we should add this line.